### PR TITLE
Add GPU-required Test Flags

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ repos:
       - id: name-tests-test
         name: check test naming
         args: [--pytest-test-first]
+        exclude: tests/utils.py
 
 ci:
   autofix_commit_msg: |

--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ uv run coverage report # Generate CLI report
 uv run coverage html   # Generate HTML report
 ```
 
+#### Running Tests with GPU
+
+Some tests may require a GPU to run. You can enable GPU tests by passing the `--gpu` option:
+
+```bash
+uv run pytest --gpu
+```
+
+These tests will be _skipped_ by default unless you specify the `--gpu` option.
+
 ### Generating Documentation
 
 To generate the documentation, you can use the following command:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,5 @@ omit = [
 
 [tool.pytest.ini_options]
 markers = [
-    "gpu_required: Mark a test as requiring a GPU.",
     "slow: Mark a test as slow.",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,3 +83,9 @@ omit = [
     "tests/*",
     "*/conftest.py",
 ]
+
+[tool.pytest.ini_options]
+markers = [
+    "gpu_required: Mark a test as requiring a GPU.",
+    "slow: Mark a test as slow.",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,12 @@
 import pytest
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--gpu", action="store_true", dest="gpu", default=False, help="enable GPU tests"
+    )
+
+
 @pytest.fixture()
 def cli_app():
     from astra_rl.cli.main import app

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1,0 +1,13 @@
+import torch
+
+from tests.utils import mark_gpu
+
+
+@mark_gpu
+def test_gpu_available():
+    # This test is a simple demonstration of how to mark a test that requires a GPU.
+    assert torch.cuda.is_available(), (
+        "CUDA is not available. Please check your GPU setup."
+    )
+    assert torch.cuda.device_count() > 0, "No CUDA devices found."
+    print("CUDA is available and at least one GPU is detected.")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,3 @@
+import pytest
+
+mark_gpu = pytest.mark.skipif("not config.getoption('gpu')")


### PR DESCRIPTION
# Pull Request

## Description

This commit implements the `--gpu` flag for running tests. When set like with `uv run pytest --gpu` tests marked with `@mark_gpu` will be run in addition to other default tests.

This approach was used instead of `pytest.mark`s because it makes running gpu-based tests opt-in only. That is, sets the default behavior to not run gpu-required tests (making the tests work by default on most systems). Systems and individuals that want to run gpu tests can do so by adding the flag

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test additions or improvements
- [ ] 🏗️ Infrastructure/build changes

## Changes Made

- Added `--gpu` decorator to mark gpu-required tests
- Added test-utility decorator `@mark_gpu` to support marking tests as GPU required
- Updated `README` to include instructions on how to run gpu-required tests. 

## Testing

<!-- Describe the tests you ran to verify your changes -->

### Test Coverage
- [x] Added tests for new functionality
- [ ] Updated existing tests
- [x] All tests pass locally (`uv run pytest`)
- [x] Code coverage maintained or improved

### Manual Testing

Ran `uv run pytest` and `uv run pytest --gpu` and observed difference in test execution.