### PR TITLE
Move to a simpler pull request template with less work

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,66 +4,20 @@
 
 <!-- Provide a brief description of the changes in this PR -->
 
-### Type of Change
+### Added
+- <!-- List new features added in this PR (if any) -->
 
-- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-- [ ] ✨ New feature (non-breaking change which adds functionality)
-- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] 📚 Documentation update
-- [ ] 🔧 Refactoring (no functional changes)
-- [ ] ⚡ Performance improvement
-- [ ] 🧪 Test additions or improvements
-- [ ] 🏗️ Infrastructure/build changes
+### Changed
+- <!-- List changes made in this PR (if any) -->
 
-## Changes Made
+### Fixed
+- <!-- List bugs fixed in this PR (if any) -->
 
-<!-- List the specific changes made in this PR -->
+### Removed
+- <!-- List features removed in this PR (if any) -->
 
-- 
-- 
-- 
+## Related Issue
+<!-- If this PR addresses a specific issue, please provide the issue number here (if any) -->
 
-## Testing
-
-<!-- Describe the tests you ran to verify your changes -->
-
-### Test Coverage
-- [ ] Added tests for new functionality
-- [ ] Updated existing tests
-- [ ] All tests pass locally (`uv run pytest`)
-- [ ] Code coverage maintained or improved
-
-### Manual Testing
-<!-- Describe any manual testing performed -->
-
-## Documentation
-
-- [ ] Updated docstrings for new/modified functions
-- [ ] Updated README.md if applicable
-- [ ] Updated documentation in `docs/` if applicable
-- [ ] Added examples for new features
-
-## Pre-submission Checklist
-
-<!-- Check all boxes that apply -->
-
-- [ ] Code follows the project's style guidelines
-- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
-- [ ] Self-review of the code completed
-- [ ] Comments added for hard-to-understand areas
-- [ ] No new warnings introduced
-- [ ] Changes are backwards compatible (or breaking changes are documented)
-
-## Related Issues
-
-<!-- Link any related issues -->
-
-Fixes #<!-- issue number -->
-Relates to #<!-- issue number -->
-
-## Focus Areas and Questions for Reviewers
-
-<!-- Any specific questions or areas of uncertainty -->
-
-- 
-- 
+## Note to Reviewers
+<!-- Any special instructions for reviewers, such as testing steps or areas of focus -->


### PR DESCRIPTION
# Pull Request

## Description

This PR moves to a simpler pull-request template. I felt the old one had a lot of checkboxes we were just ignoring anyone. We can revert later if we need more pre-submission checklists, but I have found this to be generally helpful and can make maintaining a CHANGELOG easier down the road if we want one.

### Changed
- Update PR template.